### PR TITLE
[Closes #9] Only minify on build

### DIFF
--- a/generators/gulp/templates/gulp/tasks/base.js
+++ b/generators/gulp/templates/gulp/tasks/base.js
@@ -1,0 +1,30 @@
+var gulp         = require('gulp');
+var runSequence  = require('run-sequence');
+
+//
+//   Base
+//
+//////////////////////////////////////////////////////////////////////
+
+/*
+The baseline tasks to get things going.
+*/
+
+module.exports = gulp.task('base', function(callback) {
+  runSequence(
+    'clean',
+    [
+      'templates',
+      'scripts:lint',
+      'scripts:bundle',
+      'styles',
+      'styles:copy',
+      'scripts:copy',
+      'images',
+      'svg'
+    ],
+    'rev:clear',
+    'rev',
+    callback
+  );
+});

--- a/generators/gulp/templates/gulp/tasks/build.js
+++ b/generators/gulp/templates/gulp/tasks/build.js
@@ -7,25 +7,15 @@ var runSequence  = require('run-sequence');
 //////////////////////////////////////////////////////////////////////
 
 /*
-Runs all tasks needed to produce a deployable project
+Base tasks + tasks that should be run on production
 */
 
 module.exports = gulp.task('build', function(callback) {
   runSequence(
-    'clean',
+    'base',
     [
-      'templates',
-      'scripts:lint',
-      'scripts:bundle',
-      'scripts:uglify',
-      'styles',
-      'styles:copy',
-      'scripts:copy',
-      'images',
-      'svg'
+      'scripts:uglify'
     ],
-    'rev:clear',
-    'rev',
     callback
   );
 });

--- a/generators/gulp/templates/gulp/tasks/default.js
+++ b/generators/gulp/templates/gulp/tasks/default.js
@@ -6,9 +6,13 @@ var runSequence  = require('run-sequence');
 //
 //////////////////////////////////////////////////////////////////////
 
+/*
+Base tasks + local development tasks
+*/
+
 module.exports = gulp.task('default', function(callback) {
   runSequence(
-    'build',
+    'base',
     [
       'browserSync',
       'watch'

--- a/generators/gulp/templates/gulp/tasks/scripts_uglify.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_uglify.js
@@ -11,7 +11,7 @@ var uglify       = require('gulp-uglify');
 Minimizes the size of the javascript bundle file
 */
 
-module.exports = gulp.task('scripts:uglify', ['scripts:bundle'], function() {
+module.exports = gulp.task('scripts:uglify', function() {
   return gulp.src([
     config.paths.scriptDist + '**/*.js'
   ])


### PR DESCRIPTION
Makes some moves in order to to not run minify in the `default` task.

- Moves most of the previous `default` tasks into a `base` task
- Modifies `default` to run `base` plus `browserSync` and `watch`
- Modifies `build` to run `base` plus `scripts:uglify`
- Modifies uglify to not depend on bundle (because it's only run in `build`, and in sequence we can be sure `bundle` has already been completed) 