### PR TITLE
Better webpack output

### DIFF
--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -51,16 +51,16 @@ gulp.task('scripts:bundle', ['scripts:lint'], function(callback) {
 
     plugins: [
       new CommonsChunkPlugin('common.bundle.js'),
-      
+
       // Allows us to require bower components
       // e.g. var someBowerInstalledLib = require('bower-installed-lib-name');
       new webpack.ResolverPlugin(
         new webpack.ResolverPlugin.DirectoryDescriptionFilePlugin('bower.json', ['main'])
       ),
-      
+
       // Remove duplicate code
       new webpack.optimize.DedupePlugin(),
-      
+
       // Give all modules access to jQuery
       new webpack.ProvidePlugin({
         $: 'jquery',
@@ -72,7 +72,12 @@ gulp.task('scripts:bundle', ['scripts:lint'], function(callback) {
 
   webpack(webpackConfig, function(err, stats) {
     if (err) throw new util.PluginError('webpack', err);
-    util.log('[webpack]', stats.toString({}));
+    util.log('[webpack]', stats.toString({
+      chunks: false,
+      colors: true,
+      version: false,
+      hash: false
+    }));
     browserSync.reload({ once: true });
     callback();
   });


### PR DESCRIPTION
Implements a much more compact version of the webpack output.

Here's a sample:
```
[20:38:32] Starting 'scripts:bundle'...
[20:38:33] Finished 'styles' after 3.99 s
[20:38:33] [webpack] Time: 594ms
           Asset     Size  Chunks             Chunk Names
  main.bundle.js  3.88 kB    0, 1  [emitted]  main
common.bundle.js  4.85 kB       1  [emitted]  common.bundle.js
```