### PR TITLE
Customize templates based on installed dependencies.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,9 +25,11 @@ module.exports = Generator.extend({
     this.destinationRoot(this.options.projectName);
 
     // General
-    this.fs.copy(
+    this.fs.copyTpl(
       this.templatePath('.gitignore'),
-      this.destinationPath('.gitignore')
+      this.destinationPath('.gitignore'), {
+        platform: this.options.platform
+      }
     );
 
     // Editorconfig

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -41,12 +41,26 @@ module.exports = Generator.extend({
       this.templatePath('src/styles'),
       this.destinationPath('src/styles')
     );
+    this.fs.copyTpl(
+      this.templatePath('src/styles/main.scss'),
+      this.destinationPath('src/styles/main.scss'), {
+        deps: this.options.optionalDeps
+      }
+    );
 
     // Scripts
-    this.fs.copy(
-      this.templatePath('src/scripts'),
-      this.destinationPath('src/scripts')
+    this.fs.copyTpl(
+      this.templatePath('src/scripts/main.js'),
+      this.destinationPath('src/scripts/main.js'), {
+        deps: this.options.optionalDeps
+      }
     );
+    if (this.options.optionalDeps.indexOf('one-router') > -1) {
+      this.fs.copy(
+        this.templatePath('src/scripts/modules/routes'),
+        this.destinationPath('src/scripts/modules/routes')
+      );
+    }
 
     // Package.js
     this.fs.copyTpl(
@@ -85,8 +99,7 @@ module.exports = Generator.extend({
   install: {
     installDependencies: function() {
       var dependencies = [
-        'one-router',
-        'one-sass-toolkit'
+        
       ];
 
       var self = this;
@@ -99,7 +112,7 @@ module.exports = Generator.extend({
     },
 
     craftSetup: function() {
-      if (!this.options.isCraft) return;
+      if (!this.options.platform == 'craft') return;
       // Do Craft-related stuff here in the future…
     }
   },

--- a/generators/app/modules/prompts.js
+++ b/generators/app/modules/prompts.js
@@ -76,6 +76,11 @@ module.exports = [
         checked: true
       },
       {
+        name: 'one-router',
+        value: 'one-router',
+        checked: true
+      },
+      {
         name: 'sass-mq',
         value: 'sass-mq',
         checked: true
@@ -84,19 +89,32 @@ module.exports = [
         name: 'susy',
         value: 'susy',
         checked: true
+      },
+      {
+        name: 'one-sass-toolkit',
+        value: 'one-sass-toolkit',
+        checked: true
       }
     ]
   },
 
   //
-  //   Craft
+  //   Platform
   //
   //////////////////////////////////////////////////////////////////////
   {
-    type: 'confirm',
-    name: 'isCraft',
-    message: 'Will this project use Craft CMS?',
-    default: true,
-    store: true
+    type: 'list',
+    name: 'platform',
+    message: 'What platform should the project use?',
+    choices: [
+      {
+        name: 'Static',
+        value: 'static'
+      },
+      {
+        name: 'Craft',
+        value: 'craft'
+      }
+    ]
   }
 ]

--- a/generators/app/templates/.gitignore
+++ b/generators/app/templates/.gitignore
@@ -1,3 +1,58 @@
-node_modules
-dist
+# System
+# ---------------------------
 .DS_Store
+Thumbs.db
+
+# Config
+# ---------------------------
+*.esproj
+*.sublime-project
+*.sublime-workspace
+*.tmproj
+*.tmproject
+.env
+.env.php
+.idea
+.project
+.settings
+
+# Compiled Files
+# ---------------------------
+/dist/<% if (platform == 'craft') { %>
+
+# Craft
+# ---------------------------
+/craft/plugins/*
+/craft/rev-manifest.json
+/craft/storage/
+
+# Craft Public
+# ---------------------------
+/public/.htaccess
+/public/assets/
+/public/assets/**/_*
+/public/images/
+/public/scripts/
+/public/styles/
+/public/uploads/
+/public/web.config<% } %>
+
+# Package Managers
+# ---------------------------
+/.bundle
+/vendor/
+bower_components
+node_modules
+npm-debug.log
+
+# Temp
+# ---------------------------
+.cache
+.sass-cache
+/log/*.log
+/logs/*
+/tmp
+
+# VM
+# ---------------------------
+.vagrant/*

--- a/generators/app/templates/src/scripts/main.js
+++ b/generators/app/templates/src/scripts/main.js
@@ -1,14 +1,15 @@
-var OneRouter = require('one-router');
+<% var isRouter = deps.indexOf('one-router') > -1 -%>
+<% if (isRouter) { %>var OneRouter = require('one-router');
 
-//
+<% } %>//
 //   Global App Variable
 //
 //////////////////////////////////////////////////////////////////////
 
-window.APP = window.APP || {};
+window.APP = window.APP || {};<% if (isRouter) { %>
 
 APP.globalRoute = require('./modules/routes/global_route');
-APP.indexRoute = require('./modules/routes/index_route');
+APP.indexRoute = require('./modules/routes/index_route');<% } %>
 
 
 //
@@ -16,7 +17,7 @@ APP.indexRoute = require('./modules/routes/index_route');
 //
 //////////////////////////////////////////////////////////////////////
 
-APP.init = function() {
+APP.init = function() {<% if (isRouter) { %>
   // Configure Routing
   // Each route should be defined in a routename_route.js file in /scripts/modules/routes
 
@@ -27,7 +28,7 @@ APP.init = function() {
   APP.router = new OneRouter(routes);
 
   // Trigger Global Setup
-  APP.globalRoute();
+  APP.globalRoute();<% } %>
 };
 
 

--- a/generators/app/templates/src/styles/main.scss
+++ b/generators/app/templates/src/styles/main.scss
@@ -1,8 +1,8 @@
-// Vendor
-@import "susy/sass/susy";
-@import "sass-mq/mq";
+// Vendor<% if (deps.indexOf('susy') > -1) { %>
+@import "susy/sass/susy";<% } %><% if (deps.indexOf('sass-mq') > -1) { %>
+@import "sass-mq/mq";<% } %>
 
-// Vendor
+// Resets
 @import "vendor/normalize";
 @import "vendor/reset";
 
@@ -10,12 +10,12 @@
 @import "util/*";
 
 // Variables
-@import "base/_variables";
+@import "base/_variables";<% if (deps.indexOf('one-sass-toolkit') > -1) { %>
 
 // Toolkit
 @import "one-sass-toolkit/color";
 @import "one-sass-toolkit/spacing";
-@import "one-sass-toolkit/type-styles";
+@import "one-sass-toolkit/type-styles";<% } %>
 
 // Helpers
 @import "helpers/*";

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -5,10 +5,7 @@ var yosay = require('yosay');
 
 module.exports = Generator.extend({
   prompting: function () {
-    // Greet the user
-    this.log(yosay(
-      'Welcome to the impressive ' + chalk.red('generator-one-base') + ' generator!'
-    ));
+    
   },
 
   writing: function () {
@@ -22,8 +19,15 @@ module.exports = Generator.extend({
     );
 
     this.fs.copy(
-      this.templatePath('gulp'),
-      this.destinationPath('gulp')
+      this.templatePath('gulp/tasks'),
+      this.destinationPath('gulp/tasks')
+    );
+
+    this.fs.copyTpl(
+      this.templatePath('gulp/config.js'),
+      this.destinationPath('gulp/config.js'), {
+        platform: this.options.platform
+      }
     );
   },
 

--- a/generators/gulp/templates/gulp/config.js
+++ b/generators/gulp/templates/gulp/config.js
@@ -16,9 +16,9 @@ var paths = {
   templateDist: '',
 
   imageSrc: 'src/images/',
-  imageDist: 'dist/images/',
+  imageDist: 'dist/images/',<% if (platform == 'craft') { %>
 
-  craftPath: 'craft/',
+  craftPath: 'craft/',<% } %>
 
   styleCopyPaths: [
   


### PR DESCRIPTION
Adds more flexibility by customizing the output of template based on the dependencies that are selected and the platform (e.g. Craft) chosen.

For instance, if you choose not to use `one-router` we won't copy the default route files to the project or add the default routing setup to `main.js`.

Also changed things up so that instead of asking `Does this project we use Craft?` we instead ask you to select a `Platform` for the project, which currently includes `Static` and `Craft` but in the future could also include WordPress, etc. All the `Craft` option does right now is add a `craft` path to our gulp config file and customize the `.gitignore`.