### PR TITLE
Gulp only revs css/js during the build task.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -20,7 +20,7 @@ module.exports = Generator.extend({
       this.options = options;
 
       // Compose
-      this.composeWith('one-base:gulp', {
+      this.composeWith(require.resolve('../gulp'), {
         options: this.options
       });
     }.bind(this));

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,7 +6,7 @@ var prompts = require('./modules/prompts');
 
 module.exports = Generator.extend({
   initializing: function () {
-    this.composeWith('one-base:gulp');
+    
   },
 
   prompting: function () {
@@ -18,6 +18,11 @@ module.exports = Generator.extend({
     return this.prompt(prompts).then(function (options) {
       // To access options later use this.options.someAnswer;
       this.options = options;
+
+      // Compose
+      this.composeWith('one-base:gulp', {
+        options: this.options
+      });
     }.bind(this));
   },
 

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -4,6 +4,10 @@ var chalk = require('chalk');
 var yosay = require('yosay');
 
 module.exports = Generator.extend({
+  initializing: function () {
+    this.options = this.options.options;
+  },
+
   prompting: function () {
     
   },
@@ -26,6 +30,7 @@ module.exports = Generator.extend({
     this.fs.copyTpl(
       this.templatePath('gulp/config.js'),
       this.destinationPath('gulp/config.js'), {
+        projectName: this.options.projectName,
         platform: this.options.platform
       }
     );

--- a/generators/gulp/templates/gulp/config.js
+++ b/generators/gulp/templates/gulp/config.js
@@ -1,22 +1,24 @@
+<% isCraft = platform == 'craft' -%>
+<% var rootSrcPath = isCraft ? 'public' : 'dist' -%>
 //
 //   Config
 //
 //////////////////////////////////////////////////////////////////////
 
 var paths = {
-  dist: 'dist/',
+  dist: '<%= rootSrcPath %>/',
 
   styleSrc: 'src/styles/',
-  styleDist: 'dist/styles/',
+  styleDist: '<%= rootSrcPath %>/styles/',
 
   scriptSrc: 'src/scripts/',
-  scriptDist: 'dist/scripts/',
+  scriptDist: '<%= rootSrcPath %>/scripts/',
 
   templateSrc: '',
   templateDist: '',
 
   imageSrc: 'src/images/',
-  imageDist: 'dist/images/',<% if (platform == 'craft') { %>
+  imageDist: '<%= rootSrcPath %>/images/',<% if (isCraft) { %>
 
   craftPath: 'craft/',<% } %>
 
@@ -36,7 +38,7 @@ module.exports = {
   // If you want BrowserSync to proxy an existing URL,
   // change `useProxy` to true and enter your URL as `proxyUrl`
   useProxy: false,
-  proxyUrl: 'http://app.dev',
+  proxyUrl: 'http://<%= projectName %>.dev',
 
   scripts: {
     // entry files: 

--- a/generators/gulp/templates/gulp/config.js
+++ b/generators/gulp/templates/gulp/config.js
@@ -1,5 +1,5 @@
 <% isCraft = platform == 'craft' -%>
-<% var rootSrcPath = isCraft ? 'public' : 'dist' -%>
+<% var rootSrcPath = isCraft ? 'public/dist' : 'dist' -%>
 //
 //   Config
 //

--- a/generators/gulp/templates/gulp/tasks/base.js
+++ b/generators/gulp/templates/gulp/tasks/base.js
@@ -13,6 +13,7 @@ The baseline tasks to get things going.
 module.exports = gulp.task('base', function(callback) {
   runSequence(
     'clean',
+    'rev:clear',
     [
       'templates',
       'scripts:lint',
@@ -23,8 +24,6 @@ module.exports = gulp.task('base', function(callback) {
       'images',
       'svg'
     ],
-    'rev:clear',
-    'rev',
     callback
   );
 });

--- a/generators/gulp/templates/gulp/tasks/build.js
+++ b/generators/gulp/templates/gulp/tasks/build.js
@@ -13,9 +13,8 @@ Base tasks + tasks that should be run on production
 module.exports = gulp.task('build', function(callback) {
   runSequence(
     'base',
-    [
-      'scripts:uglify'
-    ],
+    'scripts:uglify',
+    'rev',
     callback
   );
 });

--- a/generators/gulp/templates/gulp/tasks/rev.js
+++ b/generators/gulp/templates/gulp/tasks/rev.js
@@ -22,9 +22,9 @@ gulp.task('rev', ['rev:clear'], function() {
     .pipe(gulp.dest('.'))
     .pipe(rev.manifest())
     .pipe(replace('public', ''))
-    .pipe(gulp.dest(config.paths.craftPath));
+    .pipe(gulp.dest(config.paths.dist));
 });
 
 gulp.task('rev:clear', function() {
-  return del([config.paths.craftPath + 'rev-manifest.json']);
+  return del([config.paths.dist + 'rev-manifest.json']);
 });


### PR DESCRIPTION
Closes #27 

Revving is important for production to allow us to heavily cache js + css, but during development revving after every file change means that the changes take a bit longer to show up. This modifies things so that revving of assets only happens during the gulp `build` task, and never locally. Because the `rev-manifest.json` gets cleared on every file change, plugins (like Craft's `assetrev`) will fall back to using the original, non-revved asset during production.

After #30 gets merged, we may want to conditionally include the `rev` task based on whether we're using Craft or not, since it relies pretty heavily on having an established workflow for using the revved assets, which as far as I know we don't have for any other platform.

**Note:** If its not clear to everyone what "revving" is to begin with, it's the practice of adding a semi-random string of characters to the end of the filename for css, js, images, or other static assets so that you can tell the browser to cache them for a really long time, but still have the cache bust immediately when the file changes. For instance, `main.css` becomes `main-72067e9aa6.css`