### PR TITLE
Use `npm start` as the kickoff point for the app instead of `gulp`

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -19,6 +19,9 @@ module.exports = Generator.extend({
       // To access options later use this.options.someAnswer;
       this.options = options;
 
+      // Use gulp
+      this.options.isUsingGulp = true;
+
       // Compose
       this.composeWith(require.resolve('../gulp'), {
         projectName: this.options.projectName,
@@ -94,7 +97,8 @@ module.exports = Generator.extend({
           githubName: this.options.githubName,
           name: this.options.name,
           email: this.options.email,
-          website: this.options.website
+          website: this.options.website,
+          isUsingGulp: this.options.isUsingGulp
         }
       );
     },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -5,17 +5,17 @@ var yosay = require('yosay');
 var prompts = require('./modules/prompts');
 
 module.exports = Generator.extend({
-  initializing: function () {
+  initializing: function() {
     
   },
 
-  prompting: function () {
+  prompting: function() {
     // Greet the user
     this.log(yosay(
       'Welcome to the impressive ' + chalk.red('generator-one-base') + ' generator!'
     ));
 
-    return this.prompt(prompts).then(function (options) {
+    return this.prompt(prompts).then(function(options) {
       // To access options later use this.options.someAnswer;
       this.options = options;
 
@@ -27,89 +27,98 @@ module.exports = Generator.extend({
     }.bind(this));
   },
 
-  writing: function () {
-    this.destinationRoot(this.options.projectName);
+  writing: {
+    setRoot: function() {
+      this.destinationRoot(this.options.projectName);
+    },
 
-    // Git
-    if (this.options.gitInit) {
+    git: function() {
+      if (this.options.gitInit) {
+        this.fs.copyTpl(
+          this.templatePath('.gitignore'),
+          this.destinationPath('.gitignore'), {
+            platform: this.options.platform
+          }
+        );
+
+        this.fs.copy(
+          this.templatePath('.github'),
+          this.destinationPath('.github')
+        );
+      }
+    },
+
+    editorConfig: function() {
+      this.fs.copy(
+        this.templatePath('.editorconfig'),
+        this.destinationPath('.editorconfig')
+      );
+    },
+
+    styles: function() {
+      this.fs.copy(
+        this.templatePath('src/styles'),
+        this.destinationPath('src/styles')
+      );
       this.fs.copyTpl(
-        this.templatePath('.gitignore'),
-        this.destinationPath('.gitignore'), {
-          platform: this.options.platform
+        this.templatePath('src/styles/main.scss'),
+        this.destinationPath('src/styles/main.scss'), {
+          deps: this.options.optionalDeps
         }
       );
+    },
 
-      this.fs.copy(
-        this.templatePath('.github'),
-        this.destinationPath('.github')
+    scripts: function() {
+      this.fs.copyTpl(
+        this.templatePath('src/scripts/main.js'),
+        this.destinationPath('src/scripts/main.js'), {
+          deps: this.options.optionalDeps
+        }
+      );
+      if (this.options.optionalDeps.indexOf('one-router') > -1) {
+        this.fs.copy(
+          this.templatePath('src/scripts/modules/routes'),
+          this.destinationPath('src/scripts/modules/routes')
+        );
+      }
+    },
+
+    packageJson: function() {
+      this.fs.copyTpl(
+        this.templatePath('package.json'),
+        this.destinationPath('package.json'),
+        {
+          projectName: this.options.projectName,
+          projectTitle: this.options.projectTitle,
+          description: this.options.description,
+          githubName: this.options.githubName,
+          name: this.options.name,
+          email: this.options.email,
+          website: this.options.website
+        }
+      );
+    },
+
+    indexHtml: function() {
+      this.fs.copyTpl(
+        this.templatePath('index.html'),
+        this.destinationPath('index.html'),
+        {
+          projectTitle: this.options.projectTitle
+        }
+      );
+    },
+
+    readme: function() {
+      this.fs.copyTpl(
+        this.templatePath('README.md'),
+        this.destinationPath('README.md'),
+        {
+          projectTitle: this.options.projectTitle,
+          description: this.options.description
+        }
       );
     }
-
-    // Editorconfig
-    this.fs.copy(
-      this.templatePath('.editorconfig'),
-      this.destinationPath('.editorconfig')
-    );
-
-    // Styles
-    this.fs.copy(
-      this.templatePath('src/styles'),
-      this.destinationPath('src/styles')
-    );
-    this.fs.copyTpl(
-      this.templatePath('src/styles/main.scss'),
-      this.destinationPath('src/styles/main.scss'), {
-        deps: this.options.optionalDeps
-      }
-    );
-
-    // Scripts
-    this.fs.copyTpl(
-      this.templatePath('src/scripts/main.js'),
-      this.destinationPath('src/scripts/main.js'), {
-        deps: this.options.optionalDeps
-      }
-    );
-    if (this.options.optionalDeps.indexOf('one-router') > -1) {
-      this.fs.copy(
-        this.templatePath('src/scripts/modules/routes'),
-        this.destinationPath('src/scripts/modules/routes')
-      );
-    }
-
-    // Package.js
-    this.fs.copyTpl(
-      this.templatePath('package.json'),
-      this.destinationPath('package.json'),
-      {
-        projectName: this.options.projectName,
-        projectTitle: this.options.projectTitle,
-        description: this.options.description,
-        githubName: this.options.githubName,
-        name: this.options.name,
-        email: this.options.email,
-        website: this.options.website
-      }
-    );
-
-    // index.html
-    this.fs.copyTpl(
-      this.templatePath('index.html'),
-      this.destinationPath('index.html'),
-      {
-        projectTitle: this.options.projectTitle
-      }
-    );
-
-    // README.md
-    this.fs.copyTpl(
-      this.templatePath('README.md'),
-      this.destinationPath('README.md'),
-      {
-        projectTitle: this.options.projectTitle,
-        description: this.options.description
-      }
-    );
   },
 
   install: {

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -9,7 +9,7 @@
 First, make sure you have [NodeJS](http://nodejs.org), [Yarn](https://yarnpkg.com), and [Gulp](http://gulpjs.com) installed. Then:
 
 * `yarn`
-* `npm start`
+* `yarn start`
 
 ### Development Server
 

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -9,7 +9,7 @@
 First, make sure you have [NodeJS](http://nodejs.org), [Yarn](https://yarnpkg.com), and [Gulp](http://gulpjs.com) installed. Then:
 
 * `yarn`
-* `gulp`
+* `npm start`
 
 ### Development Server
 

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -17,5 +17,9 @@
   },
   "dependencies": {
 
+  },
+  "scripts": {<% if (isUsingGulp) { %>
+    "start": "gulp",
+    "build": "gulp build"<% } %>
   }
 }

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -4,36 +4,38 @@ var chalk = require('chalk');
 var yosay = require('yosay');
 
 module.exports = Generator.extend({
-  initializing: function () {
-
-  },
-
-  prompting: function () {
+  initializing: function() {
     
   },
 
-  writing: function () {
-    // Maybe not the best, but works for now
-    this.destinationRoot('./');
+  prompting: function() {
+    
+  },
 
-    // Gulp
-    this.fs.copy(
-      this.templatePath('gulpfile.js'),
-      this.destinationPath('gulpfile.js')
-    );
+  writing: {
+    setRoot: function() {
+      this.destinationRoot('./');
+    },
 
-    this.fs.copy(
-      this.templatePath('gulp/tasks'),
-      this.destinationPath('gulp/tasks')
-    );
+    gulp: function() {
+      this.fs.copy(
+        this.templatePath('gulpfile.js'),
+        this.destinationPath('gulpfile.js')
+      );
 
-    this.fs.copyTpl(
-      this.templatePath('gulp/config.js'),
-      this.destinationPath('gulp/config.js'), {
-        projectName: this.options.projectName,
-        platform: this.options.platform
-      }
-    );
+      this.fs.copy(
+        this.templatePath('gulp/tasks'),
+        this.destinationPath('gulp/tasks')
+      );
+
+      this.fs.copyTpl(
+        this.templatePath('gulp/config.js'),
+        this.destinationPath('gulp/config.js'), {
+          projectName: this.options.projectName,
+          platform: this.options.platform
+        }
+      );
+    }
   },
 
   install: {


### PR DESCRIPTION
Closes #10

See #10 for why this is a good idea, but in general using `npm start` to kick off the dev environment is better than using `gulp` because:

- It allows us to easily use the `gulp` installed local to the project which means…
- No more version mismatches between the locally-installed `gulp` and the globally installed `gulp-cli`
- Having `gulp-cli` installed globally is no longer an unspoken requirement to run the project
- `npm start` can be used as a dev kickoff point even for projects that don't use gulp meaning more consistency between projects.

This PR also includes some cleanup of our `writing` tasks for the generator, but the most important bits are in this commit https://github.com/onedesign/generator-one-base/commit/2521d21de65c13e847877f1e7e9649e93223003c

