### PR TITLE
Display JS & CSS compilation error messages in the browser (in addition to the console).

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -69,7 +69,8 @@ module.exports = Generator.extend({
         'postcss-import',
         'require-dir',
         'run-sequence',
-        'script-loader'
+        'script-loader',
+        'strip-ansi'
       ];
 
       var self = this;

--- a/generators/gulp/templates/gulp/tasks/browsersync.js
+++ b/generators/gulp/templates/gulp/tasks/browsersync.js
@@ -15,7 +15,25 @@ module.exports = gulp.task('browserSync', function() {
   var options = {
     port: 3000,
     open: false,
-    notify: false
+    notify: {
+      styles: [
+        'display: none;',
+        'padding: 9px 15px 9px;',
+        'position: fixed;',
+        'text-align: left;',
+        'font-family: monospace;',
+        'font-size: 0.7em;',
+        'line-height: 1.5;',
+        'white-space: pre;',
+        'z-index: 9999;',
+        'left: 0px;',
+        'border-top-right-radius: 4px;',
+        'bottom: 0px;',
+        'color: rgb(74, 74, 74);',
+        'background-color: rgb(20, 20, 20);',
+        'color: rgb(255, 255, 255);'
+      ]
+    }
   }
 
   if (config.useProxy) {

--- a/generators/gulp/templates/gulp/tasks/browsersync.js
+++ b/generators/gulp/templates/gulp/tasks/browsersync.js
@@ -1,6 +1,5 @@
 var config      = require('../config');
 var gulp        = require('gulp');
-var browserSync = require('browser-sync');
 
 //
 //   BrowserSync
@@ -27,5 +26,5 @@ module.exports = gulp.task('browserSync', function() {
     }
   }
 
-  browserSync.init(null, options);
+  global.browserSync.init(null, options);
 });

--- a/generators/gulp/templates/gulp/tasks/default.js
+++ b/generators/gulp/templates/gulp/tasks/default.js
@@ -1,5 +1,6 @@
 var gulp         = require('gulp');
 var runSequence  = require('run-sequence');
+global.browserSync = require('browser-sync').create();
 
 //
 //   Default

--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -27,5 +27,6 @@ module.exports = gulp.task('images', function() {
       removeViewBox: false
     }]
   }))
-  .pipe(gulp.dest(config.paths.imageDist));
+  .pipe(gulp.dest(config.paths.imageDist))
+  .pipe(global.browserSync.reload({ stream: true, once: true }));
 });

--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -72,6 +72,7 @@ gulp.task('scripts:bundle', ['scripts:lint'], function(callback) {
     }
 
     if (err) throw new util.PluginError('webpack', err);
+
     if (stats.hasErrors()) {
       var info = stats.toJson('errors-only');
       var body = info.errors.join('/n');

--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -3,6 +3,7 @@ var gulp               = require('gulp');
 var _                  = require('lodash');
 var util               = require('gulp-util');
 var path               = require('path');
+var stripAnsi          = require('strip-ansi');
 var webpack            = require('webpack');
 var CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 
@@ -75,7 +76,7 @@ gulp.task('scripts:bundle', ['scripts:lint'], function(callback) {
 
     if (stats.hasErrors()) {
       var info = stats.toJson('errors-only');
-      var body = info.errors.join('/n');
+      var body = stripAnsi(info.errors.join('/n'));
       global.browserSync.notify(body, 30000);
     } else {
       global.browserSync.reload({ once: true });

--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -1,6 +1,5 @@
 var config             = require('../config');
 var gulp               = require('gulp');
-var browserSync        = require('browser-sync');
 var _                  = require('lodash');
 var util               = require('gulp-util');
 var path               = require('path');
@@ -63,14 +62,24 @@ gulp.task('scripts:bundle', ['scripts:lint'], function(callback) {
   }
 
   webpack(webpackConfig, function(err, stats) {
+    var log = function(stats) {
+      util.log('[webpack]', stats.toString({
+        chunks: false,
+        colors: true,
+        version: false,
+        hash: false
+      }));
+    }
+
     if (err) throw new util.PluginError('webpack', err);
-    util.log('[webpack]', stats.toString({
-      chunks: false,
-      colors: true,
-      version: false,
-      hash: false
-    }));
-    browserSync.reload({ once: true });
+    if (stats.hasErrors()) {
+      var info = stats.toJson('errors-only');
+      var body = info.errors.join('/n');
+      global.browserSync.notify(body, 30000);
+    } else {
+      global.browserSync.reload({ once: true });
+    }
+    log(stats);
     callback();
   });
 });

--- a/generators/gulp/templates/gulp/tasks/styles.js
+++ b/generators/gulp/templates/gulp/tasks/styles.js
@@ -1,6 +1,5 @@
 var config       = require('../config');
 var gulp         = require('gulp');
-var browserSync  = require('browser-sync');
 var cssGlobbing  = require('gulp-css-globbing');
 var sass         = require('gulp-sass');
 var autoprefixer = require('autoprefixer');
@@ -38,9 +37,12 @@ module.exports = gulp.task('styles', function() {
   .pipe(sass({
     outputStyle: 'compressed',
     includePaths: ['./node_modules']
-  }).on('error', sass.logError))
+  }).on('error', function(error) {
+    global.browserSync.notify(error.message, 30000);
+    sass.logError.call(this, error);
+  }))
   .pipe(postcss(postCssProcessors, {}))
   .pipe(pixrem({ rootValue: '10px' }))
   .pipe(gulp.dest(config.paths.styleDist))
-  .pipe(browserSync.reload({ stream: true }));
+  .pipe(global.browserSync.reload({ stream: true }));
 });

--- a/generators/gulp/templates/gulp/tasks/svg.js
+++ b/generators/gulp/templates/gulp/tasks/svg.js
@@ -27,5 +27,6 @@ module.exports = gulp.task('svg', function() {
     config.paths.imageSrc + 'svg/*.svg'
   ])
   .pipe(svgSprite(svgSpriteConfig))
-  .pipe(gulp.dest(config.paths.imageDist + 'svg'));
+  .pipe(gulp.dest(config.paths.imageDist + 'svg'))
+  .pipe(global.browserSync.reload({ stream: true, once: true }));
 });

--- a/generators/gulp/templates/gulp/tasks/templates.js
+++ b/generators/gulp/templates/gulp/tasks/templates.js
@@ -1,6 +1,5 @@
 var config       = require('../config');
 var gulp         = require('gulp');
-var browserSync  = require('browser-sync');
 
 //
 //   Templates
@@ -16,5 +15,5 @@ module.exports = gulp.task('templates', function() {
     config.paths.templateSrc + '**/*.html',
     config.paths.templateSrc + '**/*.php'
   ])
-  .pipe(browserSync.reload({ stream: true, once: true }));
+  .pipe(global.browserSync.reload({ stream: true, once: true }));
 });


### PR DESCRIPTION
Related to #11 

Often when you're developing – especially on a smaller screen – javascript or sass compilation errors may pop up that prevent the page from loading but because you're terminal is obscured you may not notice them right away.

This PR uses Browsersync's ability to send notification messages to the browser to output the contents of these errors directly in the browser in addition to the console, calling your intention to them immediately.

While this is very nice, there is one small caveat that makes it less than ideal.

It's necessary for us to override browser syncs default notification styles, because they need to use `pre` formatting and a monospace font to display readably. However, I haven't been able to find a way to add these default styles _and_ not show Browsersync's default `Connected to Browsersync` and `Stylesheet Injected` messages, which are kind of annoying. I'm leaning slightly towards this being tolerable given the convenience of in-browser error messages, but I'll defer to the group on this tradeoff.