### PR TITLE
Updates gulp images syntax to be compatible with latest gulp-imagemin.

### DIFF
--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -15,17 +15,24 @@ module.exports = gulp.task('images', function() {
   return gulp.src([
     config.paths.imageSrc + '**/*'
   ])
-  .pipe(imagemin({
-    progressive: true,
-    svgoPlugins: [{
-      cleanupIDs: false,
-      collapseGroups: false,
-      mergePaths: false,
-      moveElemsAttrsToGroup: false,
-      moveGroupAttrsToElems: false,
-      removeUselessStrokeAndFill: false,
-      removeViewBox: false
-    }]
-  }))
+  .pipe(imagemin([
+      imagemin.jpegtran({
+        progressive: true
+      }),
+      imagemin.svgo({
+        plugins: [
+          { cleanupIDs: false },
+          { collapseGroups: false },
+          { mergePaths: false },
+          { moveElemsAttrsToGroup: false },
+          { moveGroupAttrsToElems: false },
+          { removeUselessStrokeAndFill: false },
+          { removeViewBox: false }
+        ]
+      }),
+      imagemin.gifsicle(),
+      imagemin.optipng()
+    ]
+  ))
   .pipe(gulp.dest(config.paths.imageDist));
 });


### PR DESCRIPTION
Closes #35 

Turns out the syntax we've been using in recent projects isn't actually compatible with the latest gulp-imagemin anymore, which means that we probably have projects in the wild right now which aren't even really optimizing images. This fixes that.