### PR TITLE
Added default Craft v2.6.2964 htaccess file

### DIFF
--- a/generators/craft/templates/public/htaccess
+++ b/generators/craft/templates/public/htaccess
@@ -1,0 +1,9 @@
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+
+	# Send would-be 404 requests to Craft
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteCond %{REQUEST_FILENAME} !-d
+	RewriteCond %{REQUEST_URI} !^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
+	RewriteRule (.+) index.php?p=$1 [QSA,L]
+</IfModule>


### PR DESCRIPTION
(Hopefully) closes [Issue #46](https://github.com/onedesign/generator-one-base/issues/46).