### PR TITLE
Removes .htaccess from .gitignore and automatically creates it during generation.

### DIFF
--- a/generators/app/templates/.gitignore
+++ b/generators/app/templates/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 # Craft Public
 # ---------------------------
 /public/*
+!/public/.htaccess
 !/public/index.php
 !/public/*.txt
 !/public/*.png

--- a/generators/craft/index.js
+++ b/generators/craft/index.js
@@ -50,10 +50,14 @@ module.exports = Generator.extend({
       ]);
     },
 
-    index: function() {
+    public: function() {
       this.fs.copy(
         this.templatePath('public/index.php'),
         this.destinationPath('public/index.php')
+      );
+      this.fs.copy(
+        this.destinationPath('public/htaccess'),
+        this.destinationPath('public/.htaccess')
       );
     },
 

--- a/generators/craft/templates/public/htaccess
+++ b/generators/craft/templates/public/htaccess
@@ -1,9 +1,0 @@
-<IfModule mod_rewrite.c>
-	RewriteEngine On
-
-	# Send would-be 404 requests to Craft
-	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteCond %{REQUEST_URI} !^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
-	RewriteRule (.+) index.php?p=$1 [QSA,L]
-</IfModule>


### PR DESCRIPTION
Fixes #46 

Removes the `htaccess` template we recently added because probably makes more sense to use the one craft comes with by default.