### PR TITLE
Ensures that asset-revving works for sub-pages.

### DIFF
--- a/generators/craft/templates/craft/config/assetrev.php
+++ b/generators/craft/templates/craft/config/assetrev.php
@@ -2,6 +2,7 @@
 return array(
     '*' => array(
         'manifestPath' => '../public/dist/rev-manifest.json',
-        'assetsBasePath' => ''
+        'assetsBasePath' => '../public/dist/',
+        'assetUrlPrefix' => '{siteUrl}/dist/',
     )
 );

--- a/generators/craft/templates/craft/templates/_layout.html
+++ b/generators/craft/templates/craft/templates/_layout.html
@@ -25,6 +25,6 @@
 <body class="{{ bodyClass | default('') }}">
   {% block content %}{% endblock %}
 
-  <script src="{{ rev('dist/scripts/common.bundle.js') }}"></script>
-  <script src="{{ rev('dist/scripts/main.bundle.js') }}"></script>
+  <script src="{{ rev('scripts/common.bundle.js') }}"></script>
+  <script src="{{ rev('scripts/main.bundle.js') }}"></script>
 </body>

--- a/generators/craft/templates/craft/templates/_partials/head.html
+++ b/generators/craft/templates/craft/templates/_partials/head.html
@@ -1,2 +1,2 @@
-<link rel="stylesheet" href="{{ rev('dist/styles/main.css') }}">
+<link rel="stylesheet" href="{{ rev('styles/main.css') }}">
 {% hook 'seomaticRender' %}

--- a/generators/gulp/templates/gulp/tasks/rev.js
+++ b/generators/gulp/templates/gulp/tasks/rev.js
@@ -21,7 +21,7 @@ gulp.task('rev', ['rev:clear'], function() {
     .pipe(rev())
     .pipe(gulp.dest('.'))
     .pipe(rev.manifest())
-    .pipe(replace('public/', ''))
+    .pipe(replace('public/dist/', ''))
     .pipe(gulp.dest(config.paths.dist));
 });
 


### PR DESCRIPTION
Closes #44 

Test by adding the following to Craft's `routes.php` after running the generator

```php
return array(
    'sample' => 'index',
    'sample/another-sample' => 'index'
);
```

Then visit the following URLs with Chrome's network inspector open. You should do this both without ` rev-manifest.json` created and after running `yarn run build` to create the ` rev-manifest.json`

- http://my-project.dev/
- http://my-project.dev/sample/
- http://my-project.dev/sample/another-sample