### PR TITLE
Uses absolute paths in webpack config 

### DIFF
--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -19,12 +19,12 @@ Bundles javascript files.
 gulp.task('scripts:bundle', ['scripts:lint'], function(callback) {
   var webpackConfig = {
     entry: _.reduce(config.scripts.entryFiles, function(result, name) {
-      result[name] = './' + config.paths.scriptSrc + name;
+      result[name] = path.resolve('./' + config.paths.scriptSrc + name);
       return result;
     }, {}),
 
     output: {
-      path: './' + config.paths.scriptDist,
+      path: path.resolve('./' + config.paths.scriptDist),
       filename: '[name].bundle.js'
     },
 


### PR DESCRIPTION
As of webpack v2.3.1 it doesn't seem to like relative paths. Here's a sample error I was getting

```
[14:54:59] 'base' errored after 1.08 s
[14:54:59] WebpackOptionsValidationError in plugin 'run-sequence(scripts:bundle)'
Message:
    Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./public/dist/scripts/" is not an absolute path!
Details:
    validationErrors: [object Object]
Stack:
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./public/dist/scripts/" is not an absolute path!
    at webpack (/Users/mkornatz/Code/onedesign/craft-default/node_modules/webpack/lib/webpack.js:19:9)
    at Gulp.<anonymous> (/Users/mkornatz/Code/onedesign/craft-default/gulp/tasks/scripts_bundle.js:65:3)
    at module.exports (/Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/index.js:214:10)
    at /Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/index.js:279:18
    at finish (/Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/lib/runTask.js:21:8)
    at /Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/lib/runTask.js:52:4
    at f (/Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/node_modules/once/once.js:17:25)
    at Transform.onend (/Users/mkornatz/Code/onedesign/craft-default/node_modules/orchestrator/node_modules/end-of-stream/index.js:31:18)
```