### PR TITLE
More improvements to image processing pipeline

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -56,7 +56,7 @@ module.exports = Generator.extend({
         'eslint-plugin-react',
         'gulp',
         'autoprefixer',
-        'gulp-changed',
+        'gulp-changed-in-place',
         'gulp-css-globbing',
         'gulp-eslint',
         'gulp-postcss',

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -56,6 +56,7 @@ module.exports = Generator.extend({
         'eslint-plugin-react',
         'gulp',
         'autoprefixer',
+        'gulp-changed',
         'gulp-css-globbing',
         'gulp-eslint',
         'gulp-postcss',

--- a/generators/gulp/templates/gulp/tasks/default.js
+++ b/generators/gulp/templates/gulp/tasks/default.js
@@ -19,6 +19,7 @@ module.exports = gulp.task('default', function(callback) {
       'watch',
       'images'
     ],
+    'images:watch',
     callback
   );
 });

--- a/generators/gulp/templates/gulp/tasks/default.js
+++ b/generators/gulp/templates/gulp/tasks/default.js
@@ -19,7 +19,7 @@ module.exports = gulp.task('default', function(callback) {
       'watch',
       'images'
     ],
-    'images:watch',
+    'reload',
     callback
   );
 });

--- a/generators/gulp/templates/gulp/tasks/images-watch.js
+++ b/generators/gulp/templates/gulp/tasks/images-watch.js
@@ -1,0 +1,16 @@
+var config       = require('../config');
+var gulp         = require('gulp');
+
+//
+//   Images Watch
+//
+//////////////////////////////////////////////////////////////////////
+
+/*
+Reloads the browser after images have been processed
+*/
+
+module.exports = gulp.task('images:watch', function(done) {
+  global.browserSync.reload();
+  done();
+});

--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -34,6 +34,5 @@ module.exports = gulp.task('images', function() {
       imagemin.optipng()
     ]
   ))
-  .pipe(gulp.dest(config.paths.imageDist))
-  .pipe(global.browserSync.reload({ stream: true, once: true }));
+  .pipe(gulp.dest(config.paths.imageDist));
 });

--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -13,7 +13,7 @@ Lossless optimization of image files
 
 module.exports = gulp.task('images', function() {
   return gulp.src([
-    config.paths.imageSrc + '**/*'
+    config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'
   ])
   .pipe(imagemin([
       imagemin.jpegtran({

--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -14,7 +14,7 @@ Lossless optimization of image files
 
 module.exports = gulp.task('images', function() {
   return gulp.src([
-    config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'
+    config.paths.imageSrc + '**/*'
   ])
   .pipe(changedInPlace({ firstPass: true }))
   .pipe(imagemin([

--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -1,7 +1,7 @@
-var config       = require('../config');
-var gulp         = require('gulp');
-var imagemin     = require('gulp-imagemin');
-var changed      = require('gulp-changed');
+var config          = require('../config');
+var gulp            = require('gulp');
+var imagemin        = require('gulp-imagemin');
+var changedInPlace  = require('gulp-changed-in-place');
 
 //
 //   Images
@@ -16,7 +16,7 @@ module.exports = gulp.task('images', function() {
   return gulp.src([
     config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'
   ])
-  .pipe(changed(config.paths.imageDist))
+  .pipe(changedInPlace({ firstPass: true }))
   .pipe(imagemin([
       imagemin.jpegtran({
         progressive: true

--- a/generators/gulp/templates/gulp/tasks/images.js
+++ b/generators/gulp/templates/gulp/tasks/images.js
@@ -1,6 +1,7 @@
 var config       = require('../config');
 var gulp         = require('gulp');
 var imagemin     = require('gulp-imagemin');
+var changed      = require('gulp-changed');
 
 //
 //   Images
@@ -15,6 +16,7 @@ module.exports = gulp.task('images', function() {
   return gulp.src([
     config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'
   ])
+  .pipe(changed(config.paths.imageDist))
   .pipe(imagemin([
       imagemin.jpegtran({
         progressive: true

--- a/generators/gulp/templates/gulp/tasks/reload.js
+++ b/generators/gulp/templates/gulp/tasks/reload.js
@@ -2,15 +2,15 @@ var config       = require('../config');
 var gulp         = require('gulp');
 
 //
-//   Images Watch
+//   Reload Browser
 //
 //////////////////////////////////////////////////////////////////////
 
 /*
-Reloads the browser after images have been processed
+A generic task to reload the browser when another task is complete
 */
 
-module.exports = gulp.task('images:watch', function(done) {
+module.exports = gulp.task('reload', function(done) {
   global.browserSync.reload();
   done();
 });

--- a/generators/gulp/templates/gulp/tasks/watch.js
+++ b/generators/gulp/templates/gulp/tasks/watch.js
@@ -15,5 +15,5 @@ module.exports = gulp.task('watch', function() {
   gulp.watch([config.paths.styleSrc + '**/*.scss'], function() { runSequence('styles', 'rev:clear') });
   gulp.watch([config.paths.scriptSrc + '**/*.js'], function() { runSequence(['scripts:lint', 'scripts:bundle', 'scripts:copy'], 'rev:clear') });
   gulp.watch([config.paths.templateSrc + '**/*.html', config.paths.templateSrc + '**/*.php'], function() { runSequence('templates') });
-  gulp.watch([config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'], function() { runSequence('images') });
+  gulp.watch([config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'], function() { runSequence('images', 'images:watch') });
 });

--- a/generators/gulp/templates/gulp/tasks/watch.js
+++ b/generators/gulp/templates/gulp/tasks/watch.js
@@ -15,5 +15,5 @@ module.exports = gulp.task('watch', function() {
   gulp.watch([config.paths.styleSrc + '**/*.scss'], function() { runSequence('styles', 'rev:clear') });
   gulp.watch([config.paths.scriptSrc + '**/*.js'], function() { runSequence(['scripts:lint', 'scripts:bundle', 'scripts:copy'], 'rev:clear') });
   gulp.watch([config.paths.templateSrc + '**/*.html', config.paths.templateSrc + '**/*.php'], function() { runSequence('templates') });
-  gulp.watch([config.paths.imageSrc + '**/*'], function() { runSequence('images', 'images:watch') });
+  gulp.watch([config.paths.imageSrc + '**/*'], function() { runSequence('images', 'reload') });
 });

--- a/generators/gulp/templates/gulp/tasks/watch.js
+++ b/generators/gulp/templates/gulp/tasks/watch.js
@@ -15,5 +15,5 @@ module.exports = gulp.task('watch', function() {
   gulp.watch([config.paths.styleSrc + '**/*.scss'], function() { runSequence('styles', 'rev:clear') });
   gulp.watch([config.paths.scriptSrc + '**/*.js'], function() { runSequence(['scripts:lint', 'scripts:bundle', 'scripts:copy'], 'rev:clear') });
   gulp.watch([config.paths.templateSrc + '**/*.html', config.paths.templateSrc + '**/*.php'], function() { runSequence('templates') });
-  gulp.watch([config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'], function() { runSequence('images', 'images:watch') });
+  gulp.watch([config.paths.imageSrc + '**/*'], function() { runSequence('images', 'images:watch') });
 });

--- a/generators/gulp/templates/gulp/tasks/watch.js
+++ b/generators/gulp/templates/gulp/tasks/watch.js
@@ -15,5 +15,5 @@ module.exports = gulp.task('watch', function() {
   gulp.watch([config.paths.styleSrc + '**/*.scss'], function() { runSequence('styles', 'rev:clear') });
   gulp.watch([config.paths.scriptSrc + '**/*.js'], function() { runSequence(['scripts:lint', 'scripts:bundle', 'scripts:copy'], 'rev:clear') });
   gulp.watch([config.paths.templateSrc + '**/*.html', config.paths.templateSrc + '**/*.php'], function() { runSequence('templates') });
-  gulp.watch([config.paths.imageSrc + '**/*'], function() { runSequence('images') });
+  gulp.watch([config.paths.imageSrc + '**/*.{png,gif,jpg,svg}'], function() { runSequence('images') });
 });


### PR DESCRIPTION
Makes a few more tweaks to our image processing pipeline based on some things I found experimenting with images recently:

- Browsersync wasn't working with images because… it just doesn't work. Gulp 4 will apparently fix this, but until then this is the recommended approach: https://browsersync.io/docs/gulp#gulp-reload This PR adds that task, so that whenever images finish building (either on first run or on watch changes) the browser will refresh once and only once.
- Processing images can be time-consuming, and Gulp doesn't care whether one image has changed or they all have changed, so it will process EVERY SINGLE IMAGE any time one image changes. This adds `gulp-changed-in-place` which checks to see if the image has changed (based on modification date) and only processes it if it has.