### PR TITLE
Moves all Imager config into .env

### DIFF
--- a/generators/craft/index.js
+++ b/generators/craft/index.js
@@ -76,13 +76,15 @@ module.exports = Generator.extend({
       this.fs.copyTpl(
         this.templatePath('env.sample'),
         this.destinationPath('env.sample'), {
-          projectName: this.options.projectName
+          projectName: this.options.projectName,
+          craftPlugins: this.options.craftPlugins
         }
       );
       this.fs.copyTpl(
         this.templatePath('env.sample'),
         this.destinationPath('.env'), {
-          projectName: this.options.projectName
+          projectName: this.options.projectName,
+          craftPlugins: this.options.craftPlugins
         }
       );
     },

--- a/generators/craft/templates/craft/config/imager.php
+++ b/generators/craft/templates/craft/config/imager.php
@@ -4,19 +4,22 @@
  * Configuration file for Imager
  */
 
+// Import the environment variables file path
+$env = require(dirname(dirname(__FILE__)).'/../.env.php');
+
 return array(
   // General
-  'imagerSystemPath' => $_SERVER['DOCUMENT_ROOT'] . '/imager/',
+  'imagerSystemPath' => $env['IMAGER_SYSTEM_PATH'],
 
   // Progressive Images
   'interlace' => true,
   'allowUpscale' => false,
 
   // AWS Config
-  // 'imagerUrl' => 'https://s3.amazonaws.com/<%= projectName %>/imager/',
-  // 'awsEnabled' => true,
-  // 'awsAccessKey' => '',
-  // 'awsSecretAccessKey' => '',
-  // 'awsBucket' => '<%= projectName %>',
-  // 'awsFolder' => 'imager'
+  // 'awsEnabled' => $env['AWS_ENABLED'],
+  // 'imagerUrl' => $env['IMAGER_URL'],
+  // 'awsAccessKey' => $env['AWS_ACCESS_KEY'],
+  // 'awsSecretAccessKey' => $env['AWS_SECRET_ACCESS_KEY'],
+  // 'awsBucket' => $env['AWS_BUCKET'],
+  // 'awsFolder' => $env['AWS_FOLDER']
 );

--- a/generators/craft/templates/env.sample
+++ b/generators/craft/templates/env.sample
@@ -8,4 +8,11 @@ APP_DB_USER="root"
 APP_DEV_MODE="true"
 APP_PHP_MAX_MEMORY_LIMIT="256M"
 APP_SITE_URL="http://<%= projectName %>.dev"
-APP_ENABLE_TEMPLATE_CACHING="false"
+APP_ENABLE_TEMPLATE_CACHING="false"<% if (craftPlugins.indexOf('imager') > -1) { %>
+IMAGER_SYSTEM_PATH="/path/to/<%= projectName %>/public/imager/"
+# AWS_ENABLED="true"
+# IMAGER_URL="https://s3.amazonaws.com/<%= projectName %>/imager/"
+# AWS_ACCESS_KEY=""
+# AWS_SECRET_ACCESS_KEY=""
+# AWS_BUCKET="<%= projectName %>"
+# AWS_FOLDER="imager"<% } %>


### PR DESCRIPTION
Closes #86 

Only the `IMAGER_SYSTEM_PATH` _needs_ to be moved into the environment config, but it seemed appropriate to move everything in to make things more consistent (and make it clear that all app config should be handled via env vars)