### PR TITLE
Adds ability for gulp tasks to display in-browser notifications.

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -31,6 +31,11 @@ module.exports = Generator.extend({
         this.destinationPath('gulp/tasks')
       );
 
+      this.fs.copy(
+        this.templatePath('gulp/utils'),
+        this.destinationPath('gulp/utils')
+      );
+
       this.fs.copyTpl(
         this.templatePath('gulp/config.js'),
         this.destinationPath('gulp/config.js'), {
@@ -74,6 +79,7 @@ module.exports = Generator.extend({
         'gulp-sass',
         'gulp-shell',
         'gulp-util',
+        'jsonfile',
         'node-libs-browser',
         'postcss-import',
         'require-dir',

--- a/generators/gulp/templates/gulp/tasks/browsersync.js
+++ b/generators/gulp/templates/gulp/tasks/browsersync.js
@@ -1,5 +1,7 @@
 var config      = require('../config');
 var gulp        = require('gulp');
+var Notifier    = require('../utils/notifier')();
+
 
 //
 //   BrowserSync
@@ -34,15 +36,26 @@ module.exports = gulp.task('browserSync', function() {
         'color: rgb(255, 255, 255);'
       ]
     }
-  }
+  };
 
   if (config.useProxy) {
-    options.proxy = config.proxyUrl
+    options.proxy = config.proxyUrl;
   } else {
     options.server = {
       baseDir: './'
-    }
+    };
   }
 
+  // Initialize Browsersync
   global.browserSync.init(null, options);
+
+  // Reset the initial notifications
+  Notifier.create();
+
+  // Show any outstanding errors when client is connected
+  global.browserSync.emitter.on('client:connected', function() {
+    var notifications = Notifier.getFormatted();
+    global.browserSync.notify(notifications ? notifications : 'Connected!', notifications ? 50000 : 2000);
+    Notifier.reset();
+  });
 });

--- a/generators/gulp/templates/gulp/tasks/scripts_lint.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_lint.js
@@ -1,6 +1,7 @@
 var config       = require('../config');
 var gulp         = require('gulp');
 var eslint       = require('gulp-eslint');
+var Notifier     = require('../utils/notifier')();
 
 //
 //   Scripts : Lint
@@ -8,17 +9,32 @@ var eslint       = require('gulp-eslint');
 //////////////////////////////////////////////////////////////////////
 
 /*
-Reviews files for errors and coding consistency 
+Reviews files for errors and coding consistency
 */
+
+var _resultNotifications = function(result) {
+  if (!result.messages.length) return;
+  var msg = '<br/>' + result.filePath;
+  result.messages.forEach(function(resultMessage) {
+    msg += '<br/>';
+    msg += [
+      [resultMessage.line, resultMessage.column].join(':'),
+      resultMessage.source.trim(),
+      resultMessage.message
+    ].join('   ');
+  });
+  Notifier.add('scripts:lint', msg);
+};
 
 module.exports = gulp.task('scripts:lint', function() {
   return gulp.src([
     config.paths.scriptSrc + '**/*.js',
     '!' + config.paths.scriptSrc + 'vendor/**/*.js'
   ])
-  .pipe(eslint({
-    configFile: './node_modules/eslint-config-odc/eslintrc.json',
-    useEslintrc: false
-  }))
-  .pipe(eslint.format());
+    .pipe(eslint({
+      configFile: './node_modules/eslint-config-odc/eslintrc.json',
+      useEslintrc: false
+    }))
+    .pipe(eslint.result(_resultNotifications))
+    .pipe(eslint.format());
 });

--- a/generators/gulp/templates/gulp/utils/notifier.js
+++ b/generators/gulp/templates/gulp/utils/notifier.js
@@ -1,0 +1,81 @@
+var jsonfile    = require('jsonfile');
+var fs          = require('fs');
+var path        = require('path');
+
+module.exports = function() {
+  //
+  //   Private Vars
+  //
+  //////////////////////////////////////////////////////////////////////
+
+  var self = {
+    dirPath: path.resolve('./tmp'),
+    filePath: path.resolve('./tmp/errors.json'),
+    defaultContents: { errors: [] }
+  };
+
+
+  //
+  //   Private Methods
+  //
+  //////////////////////////////////////////////////////////////////////
+
+  var _init = function() {
+
+  };
+
+
+  //
+  //   Public Methods
+  //
+  //////////////////////////////////////////////////////////////////////
+
+  self.create = function() {
+    // Create the temporary directory if it doesn't already exist
+    if (!fs.existsSync(self.dirPath)) { fs.mkdirSync(self.dirPath); }
+
+    // Attempt to read an existing file
+    var file = jsonfile.readFileSync(self.filePath, { throws: false });
+
+    // If file not found, create it
+    if (!file) { self.reset(); }
+  };
+
+  self.reset = function() {
+    jsonfile.writeFileSync(self.filePath, self.defaultContents);
+  };
+
+  self.get = function() {
+    // Attempt to read an existing file
+    var file = jsonfile.readFileSync(self.filePath, { throws: false });
+    if (file) { return file.errors; }
+    return null;
+  };
+
+  self.getFormatted = function() {
+    var messages = self.get();
+    if (messages.length) {
+      return messages.join('<br/>--------------------------------------------------------------------------------<br/>');
+    }
+    return null;
+  };
+
+  self.add = function(title, msg) {
+    var file = self.get();
+    if (!file) { self.create(); }
+    var errors = self.get();
+    errors.push([`<span>${title}</span>`, msg].join(' | '));
+    jsonfile.writeFileSync(self.filePath, { errors: errors });
+  };
+
+
+  //
+  //   Initialize
+  //
+  //////////////////////////////////////////////////////////////////////
+
+  _init();
+
+  // Return the Object
+  return self;
+};


### PR DESCRIPTION
Finishes #67 

![in-browser-linting-notifications](https://user-images.githubusercontent.com/610118/32353142-1c15e2fa-bff2-11e7-8ff6-691531ab0c50.gif)

Adds a nice system for gulp tasks displaying their errors directly in the browser, rather than just in the console where they might be ignored/buried.

We already show _breaking_ issues in the browser window – such as when compilation completely fails due to Sass or Webpack encountering an error – but this gives us the ability to display in-browser errors for events that would otherwise be difficult because the browser refreshes, such as:

- JS/CSS linting finds issues
- A recurring accessibility audit finds issues

This PR only adds in-browser notifications for ESLint issues, but will be easy to add to additional gulp tasks in the future.