### PR TITLE
Show stylelint issues in-browser and enable in-browser notification queue for gulp tasks.

### DIFF
--- a/generators/gulp/templates/gulp/tasks/default.js
+++ b/generators/gulp/templates/gulp/tasks/default.js
@@ -19,6 +19,7 @@ module.exports = gulp.task('default', function(callback) {
       'watch',
       'images'
     ],
+    'notify',
     'reload',
     callback
   );

--- a/generators/gulp/templates/gulp/tasks/notify.js
+++ b/generators/gulp/templates/gulp/tasks/notify.js
@@ -1,0 +1,17 @@
+var config       = require('../config');
+var gulp         = require('gulp');
+var Notifier     = require('../utils/notifier')();
+
+//
+//   Notify
+//
+//////////////////////////////////////////////////////////////////////
+
+/*
+Broadcasts all queued notifications as in-browser messages
+*/
+
+module.exports = gulp.task('notify', function(callback) {
+  Notifier.notify();
+  callback();
+});

--- a/generators/gulp/templates/gulp/tasks/styles.js
+++ b/generators/gulp/templates/gulp/tasks/styles.js
@@ -6,6 +6,7 @@ var autoprefixer = require('autoprefixer');
 var pixrem       = require('gulp-pixrem');
 var postcss      = require('gulp-postcss');
 var importCss    = require('postcss-import');
+var Notifier     = require('../utils/notifier')();
 
 //
 //   Styles
@@ -29,20 +30,20 @@ module.exports = gulp.task('styles', function() {
   ];
 
   return gulp.src([
-    config.paths.styleSrc + 'main.scss',
+    config.paths.styleSrc + 'main.scss'
   ])
-  .pipe(cssGlobbing({
-    extensions: ['.scss']
-  }))
-  .pipe(sass({
-    outputStyle: 'compressed',
-    includePaths: ['./node_modules']
-  }).on('error', function(error) {
-    global.browserSync.notify(error.message, 30000);
-    sass.logError.call(this, error);
-  }))
-  .pipe(postcss(postCssProcessors, {}))
-  .pipe(pixrem({ rootValue: '10px' }))
-  .pipe(gulp.dest(config.paths.styleDist))
-  .pipe(global.browserSync.reload({ stream: true }));
+    .pipe(cssGlobbing({
+      extensions: ['.scss']
+    }))
+    .pipe(sass({
+      outputStyle: 'compressed',
+      includePaths: ['./node_modules']
+    }).on('error', function(error) {
+      Notifier.queue('styles', error.message);
+      sass.logError.call(this, error);
+    }))
+    .pipe(postcss(postCssProcessors, {}))
+    .pipe(pixrem({ rootValue: '10px' }))
+    .pipe(gulp.dest(config.paths.styleDist))
+    .pipe(global.browserSync.reload({ stream: true }));
 });

--- a/generators/gulp/templates/gulp/tasks/styles_lint.js
+++ b/generators/gulp/templates/gulp/tasks/styles_lint.js
@@ -1,6 +1,7 @@
 var config       = require('../config');
 var gulp         = require('gulp');
 var styleLint    = require('gulp-stylelint');
+var Notifier     = require('../utils/notifier')();
 
 //
 //   Styles : Lint
@@ -10,6 +11,22 @@ var styleLint    = require('gulp-stylelint');
 /*
 Reviews files for errors and coding consistency
 */
+
+var _resultNotifications = function(results) {
+  results.forEach(function(result) {
+    var msg = '<br/>' + result.source;
+    result.warnings.forEach(function(warning) {
+      msg += '<br/>';
+      msg += [
+        [warning.line, warning.column].join(':'),
+        warning.text
+      ].join('   ');
+    });
+    if (result.warnings.length) {
+      Notifier.queue('styles:lint', msg);
+    }
+  });
+};
 
 module.exports = gulp.task('styles:lint', function() {
   return gulp
@@ -24,6 +41,9 @@ module.exports = gulp.task('styles:lint', function() {
         {
           formatter: 'string',
           console: true
+        },
+        {
+          formatter: _resultNotifications
         }
       ]
     }));

--- a/generators/gulp/templates/gulp/tasks/watch.js
+++ b/generators/gulp/templates/gulp/tasks/watch.js
@@ -12,8 +12,8 @@ Runs tasks when files change
 */
 
 module.exports = gulp.task('watch', function() {
-  gulp.watch([config.paths.styleSrc + '**/*.scss'], function() { runSequence('styles', 'rev:clear', 'styles:lint') });
-  gulp.watch([config.paths.scriptSrc + '**/*.js'], function() { runSequence(['scripts:lint', 'scripts:bundle', 'scripts:copy'], 'rev:clear') });
-  gulp.watch([config.paths.templateSrc + '**/*.html', config.paths.templateSrc + '**/*.php'], function() { runSequence('templates') });
-  gulp.watch([config.paths.imageSrc + '**/*'], function() { runSequence('images', 'reload') });
+  gulp.watch([config.paths.styleSrc + '**/*.scss'], function() { runSequence('styles', 'styles:lint', 'notify', 'rev:clear'); });
+  gulp.watch([config.paths.scriptSrc + '**/*.js'], function() { runSequence(['scripts:lint', 'scripts:bundle', 'scripts:copy'], 'rev:clear'); });
+  gulp.watch([config.paths.templateSrc + '**/*.html', config.paths.templateSrc + '**/*.php'], function() { runSequence('templates'); });
+  gulp.watch([config.paths.imageSrc + '**/*'], function() { runSequence('images', 'reload'); });
 });


### PR DESCRIPTION
Gulp errors that occur without reloading the browser – such as the `styles` and `styles:lint` tasks – require a different approach to in-browser notifications because multiple tasks could both be trying to show notifications at the same time. This could occur when there is both a Sass compilation error AND listing errors.

This PR handles that by creating an additional, in-memory "notifications queue" that tasks can push to, and then once all tasks have run you can show all notifications built up in the queue and then clear it. This all uses the same `Notifier` utility that was previously created, and an API for creating, formatting, and showing notifications that is very similar to what was previously created for showing notifications that _do_ require a browser refresh.

With the merging of this PR, now ALL notifications that would previously appear only in the console will be shown directly in-browser, including:

- Sass compilation errors
- Style linting errors
- JS compilation errors
- JS linting errors