### PR TITLE
Don't output ESLint warnings as in-browser notifications.

### DIFF
--- a/generators/gulp/templates/gulp/tasks/scripts_lint.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_lint.js
@@ -16,6 +16,7 @@ var _resultNotifications = function(result) {
   if (!result.messages.length) return;
   var msg = '<br/>' + result.filePath;
   result.messages.forEach(function(resultMessage) {
+    if (resultMessage.severity == 1) return;
     msg += '<br/>';
     msg += [
       [resultMessage.line, resultMessage.column].join(':'),


### PR DESCRIPTION
For instance, variables named in snake case (e.g. `my_variable`) will currently throw an in-browser notification, even though it is just a "warning" in ESLint and not an "error." In some situations, avoiding non-camel-case variable names is impossible because a 3rd-party package or API may require it.