### PR TITLE
Sort libraries in Webpack console stats by file size (largest to smallest)

### DIFF
--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -100,7 +100,8 @@ gulp.task('scripts:bundle', function(callback) {
         chunks: false,
         colors: true,
         version: false,
-        hash: false
+        hash: false,
+        modulesSort: '!size'
       }));
     }
 

--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -101,6 +101,7 @@ gulp.task('scripts:bundle', function(callback) {
         colors: true,
         version: false,
         hash: false,
+        maxModules: 50,
         modulesSort: '!size'
       }));
     }


### PR DESCRIPTION
By default, webpack will output a list of all files used in the bundle in order of id (which is based on the order they're used in the source, so not super useful).

Much more useful is to see these files listed in order of file size, from largest to smallest, so you can get a good sense of which libraries are adding the most heft to your bundle. This PR does that.