### PR TITLE
Added a line to only force SSL on production

### DIFF
--- a/generators/craft2/templates/public/htaccess
+++ b/generators/craft2/templates/public/htaccess
@@ -20,6 +20,7 @@
   # Force redirect to HTTPS
   # RewriteCond %{HTTP:X-Forwarded-Proto} !https
   # RewriteCond %{HTTPS} off
+  # RewriteCond %{HTTP_HOST} ^<%= projectName %>.com [NC]
   # RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=302,L]
 
   # Redirect non-www to www

--- a/generators/craft3/templates/web/htaccess
+++ b/generators/craft3/templates/web/htaccess
@@ -20,6 +20,7 @@
   # Force redirect to HTTPS
   # RewriteCond %{HTTP:X-Forwarded-Proto} !https
   # RewriteCond %{HTTPS} off
+  # RewriteCond %{HTTP_HOST} ^<%= projectName %>.com [NC]
   # RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [R=302,L]
 
   # Redirect non-www to www


### PR DESCRIPTION
I keep running into an issue where when you uncomment the lines you want in your `.htaccess` file to force SSL, commit the changes and push to prod, everything works great - but it breaks your local setup. This adds a check to only do it when the site's on production.

Already in use here: https://github.com/onedesign/fleetguide/blob/master/public/.htaccess#L23
And here: https://github.com/onedesign/haute-living/blob/dev/public/.htaccess#L275
And here: https://github.com/onedesign/odc-2017-annual-report/blob/feature/filter/public/.htaccess#L23