### PR TITLE
Explicitly require “util” in scripts_bundle

### DIFF
--- a/generators/gulp/templates/gulp/tasks/scripts_bundle.js
+++ b/generators/gulp/templates/gulp/tasks/scripts_bundle.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const path = require('path');
 const stripAnsi = require('strip-ansi');
 const webpack = require('webpack');
+const util = require('util');
 
 //
 //   Scripts : Bundle


### PR DESCRIPTION
This is probably a node version/environment thing. Previously, you didn't have to explicitly require `util`, but with `8.9.0` I'm now getting an error. This fixes that.