### PR TITLE
Run generators inside of a directory unless parent directory matches project name.

### DIFF
--- a/generators/craft2/index.js
+++ b/generators/craft2/index.js
@@ -9,6 +9,8 @@ const childProcess = require('child_process');
 const extend = require('lodash/extend');
 const prompts = require('./modules/prompts');
 const plugins = require('./modules/available-plugins');
+const path = require('path');
+const mkdirp = require('mkdirp');
 
 module.exports = class extends Generator {
   initializing() {
@@ -48,6 +50,15 @@ module.exports = class extends Generator {
 
       // To access props use this.props.someAnswer;
     });
+  }
+
+  default() {
+    if (path.basename(this.destinationPath()) !== this.props.projectName) {
+      const text = `\nYour project should be inside a folder named ${chalk.red(this.props.projectName)}\nI'll automatically create this folder.\n\n(If you meant to run this generator inside of an existing project directory, make sure that the ${chalk.red('Project Name')} you enter at the prompt matches the name of your current directory.)\n`;
+      this.log(chalk.yellow(text));
+      mkdirp(this.props.projectName);
+      this.destinationRoot(this.destinationPath(this.props.projectName));
+    }
   }
 
   git() {

--- a/generators/craft3/index.js
+++ b/generators/craft3/index.js
@@ -8,6 +8,8 @@ const prompts = require('./modules/prompts');
 const fs = require('fs');
 const extend = require('lodash/extend');
 const guid = require('guid');
+const path = require('path');
+const mkdirp = require('mkdirp');
 
 module.exports = class extends Generator {
   initializing() {
@@ -42,6 +44,15 @@ module.exports = class extends Generator {
 
       // To access props use this.props.someAnswer;
     });
+  }
+
+  default() {
+    if (path.basename(this.destinationPath()) !== this.props.projectName) {
+      const text = `\nYour project should be inside a folder named ${chalk.red(this.props.projectName)}\nI'll automatically create this folder.\n\n(If you meant to run this generator inside of an existing project directory, make sure that the ${chalk.red('Project Name')} you enter at the prompt matches the name of your current directory.)\n`;
+      this.log(chalk.yellow(text));
+      mkdirp(this.props.projectName);
+      this.destinationRoot(this.destinationPath(this.props.projectName));
+    }
   }
 
   git() {

--- a/generators/static/index.js
+++ b/generators/static/index.js
@@ -5,6 +5,8 @@ const prompts = require('./modules/prompts');
 const fs = require('fs');
 const extend = require('lodash/extend');
 const yosay = require('yosay');
+const path = require('path');
+const mkdirp = require('mkdirp');
 
 module.exports = class extends Generator {
   initializing() {
@@ -26,6 +28,15 @@ module.exports = class extends Generator {
 
       // To access props use this.props.someAnswer;
     });
+  }
+
+  default() {
+    if (path.basename(this.destinationPath()) !== this.props.projectName) {
+      const text = `\nYour project should be inside a folder named ${chalk.red(this.props.projectName)}\nI'll automatically create this folder.\n\n(If you meant to run this generator inside of an existing project directory, make sure that the ${chalk.red('Project Name')} you enter at the prompt matches the name of your current directory.)\n`;
+      this.log(chalk.yellow(text));
+      mkdirp(this.props.projectName);
+      this.destinationRoot(this.destinationPath(this.props.projectName));
+    }
   }
 
   git() {


### PR DESCRIPTION
Outputs the contents of the `static`, `craft2`, and `craft3` generators in a new directory matching the `projectName` unless the directory the generator is run in matches the `projectName`.

It could be argued that the other generators should also follow this logic for consistency, but since the other generators are much more likely to only be run on their own inside of existing projects, I think its fair to start here.

The one piece not implemented here that should probably be handled separately is the ability to pass in the `projectName` via a command line argument when running the generator, e.g. `yo one-base:craft3 my-craft-project`.

Getting this argument working was fairly easy, using the value of the argument as a default value for the `projectName` prompt was not as obvious.