### PR TITLE
Lock installation of webpack to v3.x until 4.x documentation is ready.

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -75,7 +75,7 @@ module.exports = class extends Generator {
 
   install() {
     const devDependencies = [
-      'webpack',
+      'webpack@^3.11.0',
       'babel-core',
       'babel-loader',
       'babel-preset-env',


### PR DESCRIPTION
Related to #124

I think we should lock installation of web pack to the latest minor version of 3.x until documentation for 4.x is available and we can devote the time to updating our webpack build, as 4.x currently gets installed by npm by default and our current web pack config is not compatible with 4.0

This is just a temporary solution until Webpack 4 docs are available and we can make the (probably fairly minor) fixes needed to bring our config up to date.