### PR TITLE
Updates Craft 2 URL

### DIFF
--- a/generators/craft2/index.js
+++ b/generators/craft2/index.js
@@ -91,7 +91,7 @@ module.exports = class extends Generator {
   downloadCraft() {
     this.log(chalk.green('Downloading Craft...'));
     const self = this;
-    const craftDownloadUrl = 'http://buildwithcraft.com/latest.zip?accept_license=yes';
+    const craftDownloadUrl = 'https://craftcms.com/latest-v2.zip';
     return download(craftDownloadUrl, this.destinationPath(), {
       extract: true
     })


### PR DESCRIPTION
With the launch of Craft 3, Craft 2's URL structure changed.