### PR TITLE
Removes gulp-util

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -91,7 +91,6 @@ module.exports = class extends Generator {
       'gulp-sass',
       'gulp-shell',
       'gulp-stylelint',
-      'gulp-util',
       'jsonfile',
       'node-libs-browser',
       'postcss-import',


### PR DESCRIPTION
Looks like we aren't using `gulp-util` anywhere, and since it's deprecated, we might as well ditch it. 

Fixes #166 