### PR TITLE
Clear the default templates installed by Craft 3 before restoring our own templates.

### DIFF
--- a/generators/craft3/index.js
+++ b/generators/craft3/index.js
@@ -103,7 +103,8 @@ module.exports = class extends Generator {
       this.destinationPath('config/db.php'),
       this.destinationPath('composer.json'),
       this.destinationPath('composer.lock'),
-      this.destinationPath('package.json')
+      this.destinationPath('package.json'),
+      this.destinationPath('templates')
     ]);
 
     // If using SEOmatic, remove default robots.txt


### PR DESCRIPTION
When we first created this Craft 3 generator (pre release candidate) Craft wasn't adding any of its own templates to the project. They've since added back a default `index.html` template, so currently the generator will have a conflict when we try to add our own templates.

This PR just ensures that we clear all of the default templates added by Craft 3.